### PR TITLE
Grpc Check: avoid using grpc_use_tls param

### DIFF
--- a/include/ppconsul/agent.h
+++ b/include/ppconsul/agent.h
@@ -88,15 +88,15 @@ namespace ppconsul { namespace agent {
             serviceID(std::move(a_strServiceID)),
             interval(interval),
             deregisterCriticalServiceAfter(deregisterCriticalServiceAfter),
-            timeout(timeout),
-            tls(false){}
+            timeout(timeout) 
+        {
+        }
 
         std::string url;
         std::string serviceID;
         duration interval;
         duration deregisterCriticalServiceAfter;
         duration timeout;
-        bool tls;
     };
 
     struct HttpCheck

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -87,7 +87,6 @@ namespace impl {
 
             void operator() (const GrpcCheck& c) const
             {
-                dst()["grpc_use_tls"] = c.tls;
                 dst()["grpc"] = c.url;
                 dst()["interval"] = to_json(c.interval);
                 if (c.timeout != decltype(c.timeout)::zero())


### PR DESCRIPTION
* after moving to sonsul 1.7.3 the parameter grpc_use_tls is reported as
    unknown and results in error. We remove the uage in it