### PR TITLE
PIPENG-3392: Ttl Service Check: pass deregister time

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -71,6 +71,7 @@ namespace impl {
             void operator() (const TtlCheck& c) const
             {
                 dst()["ttl"] = to_json(c.ttl);
+		dst ()["DeregisterCriticalServiceAfter"] = to_json(c.deregisterCriticalServiceAfter);
             }
 
             void operator() (const ScriptCheck& c) const


### PR DESCRIPTION
* deregister time period was not passed to consul fot ttl checks.
Fixed